### PR TITLE
fixed validate_path_params function

### DIFF
--- a/dflow/generator.py
+++ b/dflow/generator.py
@@ -692,7 +692,7 @@ def process_response_filter(text):
 
 def validate_path_params(url, path_params):
     ''' Check whether all path_params keys and params in url match. '''
-    return True
     url_params = re.findall("{[a-z|A-Z]+}", url)
     url_params = [url[1:-1] for url in url_params]  # Discard brackets
-    return url_params == list(path_params.keys())
+    return set(url_params) == set(path_params.keys())
+


### PR DESCRIPTION
The previous implementation of ***validate_path_params()*** function was returning True regardless or whether the keys of the path_params and the params in the url match. The corrected implementation uses set to compare the keys of the path_params and the params in the url. 