### PR TITLE
Add error message for unsuccessful responses

### DIFF
--- a/dflow/templates/actions/actions.py.jinja
+++ b/dflow/templates/actions/actions.py.jinja
@@ -41,6 +41,7 @@ try:
     )
 except:
     print(f'Error retrieving response from {{act.url}} with code {response.status_code}.')
+    dispatcher.utter_message(text = "Apologies, something went wrong.")
 {% if act.response_filter is defined %}
 {{act.response_slot}} = response.json(){{act.response_filter}}
 output.append(SlotSet('{{act.response_slot}}', {{act.response_slot}}))
@@ -221,6 +222,7 @@ class {{action.name|replace("_","")|capitalize}}(FormValidationAction):
                 output["{{slot.name}}"] = {{slot.name}}
             except:
                 print(f'Error retrieving response from {{slot.data.url}} with code {response.status_code}.')
+                dispatcher.utter_message(text = "Apologies, something went wrong.")
             {% elif slot.source_type == 'HRIParamSource' %}
             {% if slot.source_method is defined and slot.source_method == 'from_intent' %}
             intent = tracker.latest_message.get("intent", {}).get("name")


### PR DESCRIPTION
In this commit, I added error messages using dispatcher.utter_message to inform users when a response is unsuccessful.

Fixes #5 
